### PR TITLE
Fixed the RFC Metadata to not prohibit derivatives, add IETF example

### DIFF
--- a/draft.txt
+++ b/draft.txt
@@ -5,9 +5,9 @@
 Network Working Group                                           E. Kline
 Internet-Draft                                              Google Japan
 Intended status: Experimental                                  K. Duleba
-Expires: May 19, 2018                                        Z. Szamonek
+Expires: September 11, 2019                                  Z. Szamonek
                                                  Google Switzerland GmbH
-                                                       November 15, 2017
+                                                          March 10, 2019
 
 
             A Format for Self-published IP Geolocation Feeds
@@ -19,70 +19,71 @@ Abstract
    a mapping of IP address prefixes to simplified geolocation
    information, colloquially termed a geolocation "feed".  Interested
    parties can poll and parse these feeds to update or merge with other
-   geolocation data sources and procedures.
+   geolocation data sources and procedures.  This format intentionally
+   only allows specifying coarse level location.
 
    Some technical organizations operating networks that move from one
    conference location to the next have already experimentally published
    small geolocation feeds.  At least one consumer (Google) has
-   incorporated these ad hoc feeds into a geolocation data pipeline.
+   incorporated these ad hoc feeds into a geolocation data pipeline, and
+   is using it to allow ISPs to inform them where the prefixes live.
 
-   XXX NOTES TODO update geofeed contents (RIPE) 6280 - 4.1.1 network-
-   based positioning system implicit use policy for LRs andy newton's
-   feedback (whois/rdap, dns, ...) consumer => Location Recipient
-   privacy and other work into new #3 section about RM, LG, and LS then
-   transmitted LR policy and LR section (current #4) A1-A4 Look at PIDF-
-   LO specify a media type (application/csv) allow repeated fields for
-   multiple regions from London: - add use case for more granularity (?)
-   - include ISP privacy info URL - User can discover if they're in a
-   feed, increases transparency - RIPE whois field, RDAP - create link
-   relationship, RFC 5988 References: - opengeofeed.org -
-   https://www.opengeofeed.org/feed/public.csv - Mozilla Location
-   Service https://location.services.mozilla.com/ -
-   https://bugzilla.mozilla.org/show_bug.cgi?id=1042925
+   [RFC Ed - Please remove publication: The IETF Meeting network
+   currently publishes a feed in this format at:
+   https://noc.ietf.org/geo/google.csv -- this has significantly cut
+   down on the number of "Gah!  Why does the network believe I'm in
+   Montreal, that was last meeting!  How am I supposed to find a pub?!"
+   complaints.  A number of other meeting networks, including RIPE and
+   ICANN publish this information as well, see below. ]
+
+   [ Ed note: Text inside square brackets ([]) is additional background
+   information, answers to frequently asked questions, general musings,
+   etc.  They will be removed before publication.]
+
+   [ This document is being collaborated on in Github at:
+   https://github.com/google/self-published-geo . The most recent
+   version of the document, open issues, etc should all be available
+   here.  The authors (gratefully) accept pull requests ]
 
 Status of This Memo
 
    This Internet-Draft is submitted in full conformance with the
    provisions of BCP 78 and BCP 79.
 
+
+
+
+Kline, et al.          Expires September 11, 2019               [Page 1]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at http://datatracker.ietf.org/drafts/current/.
-
-
-
-
-Kline, et al.             Expires May 19, 2018                  [Page 1]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 19, 2018.
+   This Internet-Draft will expire on September 11, 2019.
 
 Copyright Notice
 
-   Copyright (c) 2017 IETF Trust and the persons identified as the
+   Copyright (c) 2019 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
-   (http://trustee.ietf.org/license-info) in effect on the date of
+   (https://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
    include Simplified BSD License text as described in Section 4.e of
    the Trust Legal Provisions and are provided without warranty as
    described in the Simplified BSD License.
-
-   This document may not be modified, and derivative works of it may not
-   be created, except to format it for publication as an RFC or to
-   translate it into languages other than English.
 
 Table of Contents
 
@@ -93,39 +94,44 @@ Table of Contents
    2.  Self-published IP geolocation feeds . . . . . . . . . . . . .   4
      2.1.  Specification . . . . . . . . . . . . . . . . . . . . . .   4
        2.1.1.  Geolocation feed individual entry fields  . . . . . .   5
+         2.1.1.1.  IP Prefix . . . . . . . . . . . . . . . . . . . .   5
+         2.1.1.2.  Country . . . . . . . . . . . . . . . . . . . . .   5
+         2.1.1.3.  Region  . . . . . . . . . . . . . . . . . . . . .   5
+         2.1.1.4.  City  . . . . . . . . . . . . . . . . . . . . . .   6
+         2.1.1.5.  Postal code . . . . . . . . . . . . . . . . . . .   6
        2.1.2.  Prefixes with no geolocation information  . . . . . .   6
        2.1.3.  Additional parsing requirements . . . . . . . . . . .   6
        2.1.4.  Looking up an IP address  . . . . . . . . . . . . . .   7
      2.2.  Examples  . . . . . . . . . . . . . . . . . . . . . . . .   7
      2.3.  Proposed extensions . . . . . . . . . . . . . . . . . . .   8
-       2.3.1.  Delegation size . . . . . . . . . . . . . . . . . . .   8
-       2.3.2.  Alternate format  . . . . . . . . . . . . . . . . . .   8
+       2.3.1.  Delegation size . . . . . . . . . . . . . . . . . . .   9
+       2.3.2.  Alternate format  . . . . . . . . . . . . . . . . . .   9
+
+
+
+Kline, et al.          Expires September 11, 2019               [Page 2]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
    3.  Consuming self-published IP geolocation feeds . . . . . . . .   9
      3.1.  Feed integrity  . . . . . . . . . . . . . . . . . . . . .   9
      3.2.  Verification of authority . . . . . . . . . . . . . . . .   9
-     3.3.  Verification of accuracy  . . . . . . . . . . . . . . . .   9
-     3.4.  Refreshing feed information . . . . . . . . . . . . . . .   9
+     3.3.  Verification of accuracy  . . . . . . . . . . . . . . . .  10
+     3.4.  Refreshing feed information . . . . . . . . . . . . . . .  10
    4.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  10
-
-
-
-Kline, et al.             Expires May 19, 2018                  [Page 2]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
-   5.  Relation to other work  . . . . . . . . . . . . . . . . . . .  10
+   5.  Relation to other work  . . . . . . . . . . . . . . . . . . .  11
    6.  Security Considerations . . . . . . . . . . . . . . . . . . .  11
-   7.  Finding self-published IP geolocation feeds . . . . . . . . .  11
-     7.1.  Ad hoc 'well known' URIs  . . . . . . . . . . . . . . . .  11
+   7.  Finding self-published IP geolocation feeds . . . . . . . . .  12
+     7.1.  Ad hoc 'well known' URIs  . . . . . . . . . . . . . . . .  12
      7.2.  Using public databases of network authority . . . . . . .  12
-     7.3.  Using 'reverse' DNS with NAPTR records  . . . . . . . . .  12
-   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
+     7.3.  Using 'reverse' DNS with NAPTR records  . . . . . . . . .  13
+   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
    9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
      9.1.  Normative References  . . . . . . . . . . . . . . . . . .  14
-     9.2.  Informative References  . . . . . . . . . . . . . . . . .  14
-     9.3.  URIs  . . . . . . . . . . . . . . . . . . . . . . . . . .  16
-   Appendix A.  Sample Python validation code  . . . . . . . . . . .  16
+     9.2.  Informative References  . . . . . . . . . . . . . . . . .  15
+     9.3.  URIs  . . . . . . . . . . . . . . . . . . . . . . . . . .  17
+   Appendix A.  Sample Python validation code  . . . . . . . . . . .  17
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  23
 
 1.  Introduction
@@ -156,25 +162,22 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
 
    Some technical organizations operating networks that move from one
    conference location to the next have already experimentally published
+
+
+
+Kline, et al.          Expires September 11, 2019               [Page 3]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
    small geolocation feeds.  At least one consumer (Google) has
    incorporated these ad hoc feeds into a geolocation data pipeline.
-
-
-
-
-
-
-
-Kline, et al.             Expires May 19, 2018                  [Page 3]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
 
 1.2.  Requirements notation
 
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
-   document are to be interpreted as described in [RFC2119].
+   document are to be interpreted as described in RFC2119.
 
 1.3.  Implications of publication
 
@@ -215,16 +218,16 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    For operational simplicity, every feed should contain data about all
    IP addresses the provider wants to publish.  Alternatives, like
    publishing only entries for IP addresses whose geolocation data has
+
+
+
+Kline, et al.          Expires September 11, 2019               [Page 4]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
    changed or differ from current observed geolocation behavior "at
    large", are likely to be too operationally complex.
-
-
-
-
-Kline, et al.             Expires May 19, 2018                  [Page 4]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
 
    Feeds MUST use UTF-8 [RFC3629] character encoding.  Text after a '#'
    character is treated as a comment only and ignored.  Blank lines are
@@ -268,19 +271,21 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    Examples include "ID-RI" for the Riau province of Indonesia and "NG-
    RI" for the Rivers province in Nigeria.
 
+
+
+
+
+
+
+Kline, et al.          Expires September 11, 2019               [Page 5]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
 2.1.1.4.  City
 
    OPTIONAL.  The city field, if non-empty, SHOULD be free UTF-8 text,
    excluding the comma (',') character.
-
-
-
-
-
-Kline, et al.             Expires May 19, 2018                  [Page 5]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
 
    Examples include "Dublin", "New York", and "Sao Paulo" (specifically
    "S" followed by 0xc3, 0xa3, and "o Paulo").
@@ -325,18 +330,18 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    fields, consumers MUST nevertheless accept all valid string
    representations.
 
+
+
+
+Kline, et al.          Expires September 11, 2019               [Page 6]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
    Duplicate IP address or prefix entries MUST be considered an error,
    and consumer implementations SHOULD log the repeated entries for
    further administrative review.  Publishers SHOULD take measures to
    ensure there is one and only one entry per IP address and prefix.
-
-
-
-
-Kline, et al.             Expires May 19, 2018                  [Page 6]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
 
    Feed entries with non-empty optional fields which fail to parse,
    either in part or in full, SHOULD be discarded.  It is RECOMMENDED
@@ -365,34 +370,52 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
        2001:db8::/32,PL,,,
        2001:db8:cafe::/48,PL,PL-MZ,,02-784
 
+   The IETF network publishes geolocation information for the meeting
+   prefixes, and generally just comment out the last meeting information
+   and append the new meeting information.  The [GEO_IETF] at the time
+   of this writing contains:
+
+# IETF 104, March 2019 - Prague, CZ.
+# Note that Prague changed from CZ-PR to CZ-10 2016-11-15 - https://www.iso.org/obp/ui/#iso:code:3166:CZ
+130.129.0.0/16,CZ,CZ-10,Prague,
+2001:df8::/32,CZ,CZ-10,Prague,
+31.133.128.0/18,CZ,CZ-10,Prague,
+31.130.224.0/20,CZ,CZ-10,Prague,
+2001:67c:1230::/46,CZ,CZ-10,Prague,
+2001:67c:370::/48,CZ,CZ-10,Prague,
+
+
+
+
+
+
+Kline, et al.          Expires September 11, 2019               [Page 7]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
    Experimentally, RIPE has published geolocation information for their
    conference network prefixes, which change location in accordance with
    each new event.  [GEO_RIPE_NCC] at the time of writing contains:
 
-       193.0.24.0/21,IE,IE-D,Dublin,
-       2001:67c:64::/48,IE,IE-D,Dublin,
+      193.0.24.0/21,IS,IS-1,Reykjavik,
+      2001:67c:64::/48,IS,IS-1,Reykjavik,
 
    Similarly, ICANN has published geolocation information for their
    portable conference network prefixes.  [GEO_ICANN] at the time of
    writing contains:
 
-       199.91.192.0/21,US,US-CA,Los Angeles,
-       2620:f:8000::/48,US,US-CA,Los Angeles,
+      199.91.192.0/21,ES,ES-CT,Barcelona
+      2620:f:8000::/48,ES,ES-CT,Barcelona
+
+   A longer example is the [GEO_Google] Google Corp Geofeed, which lists
+   the geo-location information for Google coroprate offices.
 
    Furthermore, it is worth noting that the geolocation data of SixXS
    users, already available at whois.sixxs.net, is now also accessible
    in the format described here (see [GEO_SIXXS]).  This can be
    particularly useful where tunnel broker networks [RFC3053] are
    concerned as:
-
-
-
-
-
-Kline, et al.             Expires May 19, 2018                  [Page 7]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
 
    o  the geolocation attributes of users with neighboring prefixes can
       be quite different and therefore not easily aggregated, and
@@ -414,6 +437,18 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
 
    The following have been only informally discussed and are not in use
    at the time of writing.
+
+
+
+
+
+
+
+
+Kline, et al.          Expires September 11, 2019               [Page 8]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
 
 2.3.1.  Delegation size
 
@@ -442,14 +477,6 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    However, at the time of writing no such specification nor
    implementation exists.
 
-
-
-
-Kline, et al.             Expires May 19, 2018                  [Page 8]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
 3.  Consuming self-published IP geolocation feeds
 
    Consumers MAY treat published feed data as a hint only and MAY choose
@@ -471,6 +498,14 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    form of verification that the publisher is in fact authoritative for
    the addresses in the feed.  The actual means of verification is
    likely dependent upon the way in which the feed is discovered.  Ad
+
+
+
+Kline, et al.          Expires September 11, 2019               [Page 9]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
    hoc shared URIs, for example, will likely require an ad hoc
    verification process.  Future automated means of feed discovery
    SHOULD have an accompanying automated means of verification.
@@ -498,14 +533,6 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    As a publisher can change geolocation data at any time and without
    notification consumers SHOULD implement mechanisms to periodically
    refresh local copies of feed data.  In the absence of any other
-
-
-
-Kline, et al.             Expires May 19, 2018                  [Page 9]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
    refresh timing information it is recommended that consumers SHOULD
    refresh feeds no less often than weekly.
 
@@ -526,6 +553,14 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    [6] of a chosen geolocation policy is highly recommended, including
    an understanding of some of the limitations of information obscurity
    [7] (see also [RFC6772]).
+
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 10]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
 
    As noted in Section 2.1, each location field in an entry is optional,
    in order to support expressing only the level of specificity which
@@ -555,13 +590,6 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    to the following privacy policy (vis. the definition of the
    'building' [8] level of disclosure):
 
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 10]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
        <ruleset>
          <rule>
            <conditions/>
@@ -580,6 +608,15 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    given IP address, self-publication of this data fundamentally opens
    no new attack vectors.  For publishers, self-published data merely
    increases the ease with which such location data might be exploited.
+
+
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 11]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
 
    For consumers, feed retrieval processes may receive input from
    potentially hostile sources (e.g. in the event of hijacked traffic).
@@ -610,14 +647,6 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
 
    o  personal knowledge of the parties involved in the exchange, and
 
-
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 11]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
    o  comparison of feed-advertised prefixes with the BGP-advertised
       prefixes of Autonomous System Numbers known to be operated by the
       publishers.
@@ -637,6 +666,13 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    Verification may be performed if the same or similarly authoritative
    service provides the identical feed URI for queries for each CIDR
    prefix in the geolocation feed.
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 12]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
 
    The burden of serving this data to all interested consumers,
    especially the load imposed by any verification process, is not yet
@@ -666,14 +702,6 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    Attempts to locate the geolocation feed for a given IP address would
    begin by querying directly for a NAPTR record associated with the
    address's PTR-style name.  For example, 192.0.2.4 and 2001:db8::6
-
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 12]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
    would cause a NAPTR record request to be issued for "4.2.0.192.in-
    addr.arpa" and "6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d
    .0.1.0.0.2.ip6.arpa", respectively.
@@ -693,6 +721,14 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
 
    Any successfully located feed URIs could then be processed as
    outlined by this document.
+
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 13]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
 
    Verification of the contents of a feed would proceed in essentially
    the same way.  CIDR prefixes may be verified by constructing a query
@@ -719,50 +755,45 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
    Pelt, and Bjoern A.  Zeeb.  Richard L.  Barnes in particular
    contributed substantial review, text, and advice.
 
-
-
-
-
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 13]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
 9.  References
 
 9.1.  Normative References
 
    [ISO.3166.1alpha2]
               International Organization for Standardization, "ISO
-              3166-1 decoding table", <http://www.iso.org/iso/home/
-              standards/country_codes/iso-3166-1_decoding_table.htm>.
+              3166-1 decoding table",
+              <http://www.iso.org/iso/home/standards/country_codes/
+              iso-3166-1_decoding_table.htm>.
 
    [ISO.3166.2]
               International Organization for Standardization, "ISO
               3166-2:2007", <http://www.iso.org/iso/home/standards/
               country_codes.htm#2012_iso3166-2>.
 
-   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
-              Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/
-              RFC2119, March 1997, <https://www.rfc-editor.org/info/
-              rfc2119>.
-
    [RFC2616]  Fielding, R., Gettys, J., Mogul, J., Frystyk, H.,
               Masinter, L., Leach, P., and T. Berners-Lee, "Hypertext
-              Transfer Protocol -- HTTP/1.1", RFC 2616, DOI 10.17487/
-              RFC2616, June 1999, <https://www.rfc-editor.org/info/
-              rfc2616>.
+              Transfer Protocol -- HTTP/1.1", RFC 2616,
+              DOI 10.17487/RFC2616, June 1999,
+              <https://www.rfc-editor.org/info/rfc2616>.
+
+
+
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 14]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
 
    [RFC3629]  Yergeau, F., "UTF-8, a transformation format of ISO
               10646", STD 63, RFC 3629, DOI 10.17487/RFC3629, November
               2003, <https://www.rfc-editor.org/info/rfc3629>.
 
    [RFC4180]  Shafranovich, Y., "Common Format and MIME Type for Comma-
-              Separated Values (CSV) Files", RFC 4180, DOI 10.17487/
-              RFC4180, October 2005, <https://www.rfc-editor.org/info/
-              rfc4180>.
+              Separated Values (CSV) Files", RFC 4180,
+              DOI 10.17487/RFC4180, October 2005,
+              <https://www.rfc-editor.org/info/rfc4180>.
 
    [RFC4291]  Hinden, R. and S. Deering, "IP Version 6 Addressing
               Architecture", RFC 4291, DOI 10.17487/RFC4291, February
@@ -775,72 +806,73 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
 
 9.2.  Informative References
 
-   [GEOPRIV]  Internet Engineering Task Force, "IETF geopriv Working
-              Group", <http://datatracker.ietf.org/wg/geopriv/>.
-
-
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 14]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
+   [GEO_Google]
+              Google, LLC, "Google Corp Geofeed",
+              <https://www.gstatic.com/geofeed/corp_external>.
 
    [GEO_ICANN]
               Internet Corporation For Assigned Names and Numbers,
               "ICANN Meeting Geolocation Data",
               <https://registration.icann.org/geo/google.csv>.
 
+   [GEO_IETF]
+              Kumari, A., "IETF Meeting Network Geolocation Data",
+              <https://noc.ietf.org/geo/google.csv>.
+
    [GEO_RIPE_NCC]
               Schepers, M., "RIPE NCC Meeting Geolocation Data",
               <https://meetings.ripe.net/geo/google.csv>.
 
    [GEO_SIXXS]
-              van Pelt, P., "SixXS Geolocation Data", <https://www.sixxs
-              .net/export/google/>.
+              van Pelt, P., "SixXS Geolocation Data",
+              <https://www.sixxs.net/export/google/>.
+
+   [GEOPRIV]  Internet Engineering Task Force, "IETF geopriv Working
+              Group", <http://datatracker.ietf.org/wg/geopriv/>.
 
    [IPADDR_PY]
               Shields, M. and P. Moody, "Python IP address manipulation
               library", <http://code.google.com/p/ipaddr-py/>.
 
-   [RFC2818]  Rescorla, E., "HTTP Over TLS", RFC 2818, DOI 10.17487/
-              RFC2818, May 2000, <https://www.rfc-editor.org/info/
-              rfc2818>.
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 15]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
+   [RFC2818]  Rescorla, E., "HTTP Over TLS", RFC 2818,
+              DOI 10.17487/RFC2818, May 2000,
+              <https://www.rfc-editor.org/info/rfc2818>.
 
    [RFC3053]  Durand, A., Fasano, P., Guardini, I., and D. Lento, "IPv6
               Tunnel Broker", RFC 3053, DOI 10.17487/RFC3053, January
               2001, <https://www.rfc-editor.org/info/rfc3053>.
 
    [RFC3403]  Mealling, M., "Dynamic Delegation Discovery System (DDDS)
-              Part Three: The Domain Name System (DNS) Database", RFC
-              3403, DOI 10.17487/RFC3403, October 2002, <https://www
-              .rfc-editor.org/info/rfc3403>.
+              Part Three: The Domain Name System (DNS) Database",
+              RFC 3403, DOI 10.17487/RFC3403, October 2002,
+              <https://www.rfc-editor.org/info/rfc3403>.
 
-   [RFC3912]  Daigle, L., "WHOIS Protocol Specification", RFC 3912, DOI
-              10.17487/RFC3912, September 2004, <https://www.rfc-editor
-              .org/info/rfc3912>.
+   [RFC3912]  Daigle, L., "WHOIS Protocol Specification", RFC 3912,
+              DOI 10.17487/RFC3912, September 2004,
+              <https://www.rfc-editor.org/info/rfc3912>.
 
    [RFC4408]  Wong, M. and W. Schlitt, "Sender Policy Framework (SPF)
-              for Authorizing Use of Domains in E-Mail, Version 1", RFC
-              4408, DOI 10.17487/RFC4408, April 2006, <https://www.rfc-
-              editor.org/info/rfc4408>.
+              for Authorizing Use of Domains in E-Mail, Version 1",
+              RFC 4408, DOI 10.17487/RFC4408, April 2006,
+              <https://www.rfc-editor.org/info/rfc4408>.
 
    [RFC4627]  Crockford, D., "The application/json Media Type for
-              JavaScript Object Notation (JSON)", RFC 4627, DOI 10
-              .17487/RFC4627, July 2006, <https://www.rfc-editor.org/
-              info/rfc4627>.
+              JavaScript Object Notation (JSON)", RFC 4627,
+              DOI 10.17487/RFC4627, July 2006,
+              <https://www.rfc-editor.org/info/rfc4627>.
 
    [RFC4848]  Daigle, L., "Domain-Based Application Service Location
               Using URIs and the Dynamic Delegation Discovery Service
               (DDDS)", RFC 4848, DOI 10.17487/RFC4848, April 2007,
               <https://www.rfc-editor.org/info/rfc4848>.
-
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 15]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
 
    [RFC5139]  Thomson, M. and J. Winterbottom, "Revised Civic Location
               Format for Presence Information Data Format Location
@@ -848,15 +880,23 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
               February 2008, <https://www.rfc-editor.org/info/rfc5139>.
 
    [RFC5952]  Kawamura, S. and M. Kawashima, "A Recommendation for IPv6
-              Address Text Representation", RFC 5952, DOI 10.17487/
-              RFC5952, August 2010, <https://www.rfc-editor.org/info/
-              rfc5952>.
+              Address Text Representation", RFC 5952,
+              DOI 10.17487/RFC5952, August 2010,
+              <https://www.rfc-editor.org/info/rfc5952>.
 
    [RFC6772]  Schulzrinne, H., Ed., Tschofenig, H., Ed., Cuellar, J.,
               Polk, J., Morris, J., and M. Thomson, "Geolocation Policy:
               A Document Format for Expressing Privacy Preferences for
               Location Information", RFC 6772, DOI 10.17487/RFC6772,
               January 2013, <https://www.rfc-editor.org/info/rfc6772>.
+
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 16]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
 
 9.3.  URIs
 
@@ -891,13 +931,6 @@ Appendix A.  Sample Python validation code
    use of the open source ipaddr Python library for IP address and CIDR
    parsing and validation [IPADDR_PY].
 
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 16]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
 #!/usr/bin/python
 #
 # Copyright (c) 2012 IETF Trust and the persons identified as authors of
@@ -913,6 +946,14 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
 This tool reads CSV data in the self-published ipgeo feed format from
 the standard input and performs basic validation.  It is intended for
 use by feed publishers before launching a feed.
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 17]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
 """
 
 import csv
@@ -946,14 +987,6 @@ class IPGeoFeedValidator(object):
     Args:
       logfile: a file object (e.g., sys.stdout or sys.stderr) or None.
     """
-
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 17]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
     self.output_stream = logfile
 
   def CountErrors(self, severity):
@@ -969,6 +1002,13 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
 
     if self._ShouldIgnoreLine(line):
       return
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 18]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
 
     fields = [field for field in csv.reader([line])][0]
 
@@ -1002,14 +1042,6 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
       return self._IsCIDRCorrect(field)
     return self._IsIPAddressCorrect(field)
 
-
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 18]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
   def _IsCIDRCorrect(self, cidr):
     try:
       ipprefix = ipaddr.IPNetwork(cidr)
@@ -1026,6 +1058,14 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
 
   def _IsIPAddressCorrect(self, ipaddress):
     try:
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 19]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
       ip = ipaddr.IPAddress(ipaddress)
     except:
       self._ReportError('Incorrect IP Address.')
@@ -1058,14 +1098,6 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
     return True
 
   ############################################################
-
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 19]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
   def _ReportError(self, message):
     self._ReportWithSeverity('ERROR', message)
 
@@ -1082,6 +1114,13 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
 
     if self.output_stream is not None:
       self.output_stream.write(output_line)
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 20]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
 
   def _FlushOutputStream(self):
     if self.is_correct_line: return
@@ -1115,13 +1154,6 @@ if __name__ == '__main__':
 # License set forth in Section 4.c of the IETF Trust's Legal Provisions
 # Relating to IETF Documents (http://trustee.ietf.org/license-info).
 
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 20]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
 import sys
 from ipgeo_feed_validator import IPGeoFeedValidator
 
@@ -1138,6 +1170,14 @@ class IPGeoFeedValidatorTest(object):
     self.TestFeedLine('', 0, 0)
 
     self.TestFeedLine('asdf', 1, 1)
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 21]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
+
     self.TestFeedLine('asdf,US,,,', 1, 0)
     self.TestFeedLine('aaaa::,US,,,', 0, 0)
     self.TestFeedLine('zzzz::,US', 1, 1)
@@ -1170,14 +1210,6 @@ class IPGeoFeedValidatorTest(object):
     self.TestFeedLine('55.66.77.88/24,US,,,', 1, 0)
     self.TestFeedLine('55.66.77.88/32,US,,,', 0, 0)
     self.TestFeedLine('55.66.77/24,US,,,', 1, 0)
-
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 21]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
     self.TestFeedLine('55.66.77.0/35,US,,,', 1, 0)
 
     self.TestFeedLine('172.15.30.1,US,,,', 0, 0)
@@ -1193,6 +1225,14 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
 
   def IsOutputLogCorrectAtSeverity(self, severity, expected_msg_count):
     msg_count = self.validator.CountErrors(severity)
+
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 22]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
+
 
     if msg_count != expected_msg_count:
       print 'TEST FAILED: %s\nexpected %d %s[s], observed %d\n%s\n' % (
@@ -1227,13 +1267,6 @@ Internet-Draft         Self-published IP Geofeeds          November 2017
 if __name__ == '__main__':
   IPGeoFeedValidatorTest().Run()
 
-
-
-Kline, et al.             Expires May 19, 2018                 [Page 22]
-
-Internet-Draft         Self-published IP Geofeeds          November 2017
-
-
 Authors' Addresses
 
    Erik Kline
@@ -1244,6 +1277,17 @@ Authors' Addresses
 
    Phone: +81 03 6384 9000
    Email: ek@google.com
+
+
+
+
+
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 23]
+
+Internet-Draft         Self-published IP Geofeeds             March 2019
 
 
    Krzysztof Duleba
@@ -1285,4 +1329,16 @@ Authors' Addresses
 
 
 
-Kline, et al.             Expires May 19, 2018                 [Page 23]
+
+
+
+
+
+
+
+
+
+
+
+
+Kline, et al.          Expires September 11, 2019              [Page 24]

--- a/draft.xml
+++ b/draft.xml
@@ -1,66 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
-    <!ENTITY rfc2119 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
-    <!ENTITY rfc2616 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2616.xml">
-    <!ENTITY rfc2818 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2818.xml">
-    <!ENTITY rfc3053 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3053.xml">
-    <!ENTITY rfc3403 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3403.xml">
-    <!ENTITY rfc3629 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3629.xml">
-    <!ENTITY rfc3912 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3912.xml">
-    <!ENTITY rfc4180 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4180.xml">
-    <!ENTITY rfc4291 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4291.xml">
-    <!ENTITY rfc4408 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4408.xml">
-    <!ENTITY rfc4627 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4627.xml">
-    <!ENTITY rfc4632 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4632.xml">
-    <!ENTITY rfc4848 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4848.xml">
-    <!ENTITY rfc5139 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5139.xml">
-    <!ENTITY rfc5952 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5952.xml">
-    <!ENTITY rfc6772 PUBLIC ""
-      "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6772.xml">
-]>
-
-<rfc category="exp"
-     ipr="noModificationTrust200902"
-     docName="draft-google-self-published-geofeeds-03">
-
 <?xml-stylesheet type="text/xsl" href="rfc2629.xslt" ?>
-
-<?rfc toc="yes" ?>
-<?rfc symrefs="yes" ?>
+<!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+<?rfc toc="yes"?>
+<?rfc tocdepth="4"?>
 <?rfc sortrefs="yes"?>
-<?rfc iprnotified="no" ?>
-<?rfc strict="yes" ?>
-<?rfc compact="yes" ?>
-<?rfc subcompact="no" ?>
+<?rfc symrefs="yes"?>
+<rfc category="exp" docName="draft-google-self-published-geofeeds-03"
+     ipr="trust200902">
+  <?xml-stylesheet type="text/xsl" href="rfc2629.xslt" ?>
+
+  <?rfc toc="yes" ?>
+
+  <?rfc symrefs="yes" ?>
+
+  <?rfc sortrefs="yes"?>
+
+  <?rfc iprnotified="no" ?>
+
+  <?rfc strict="yes" ?>
+
+  <?rfc compact="yes" ?>
+
+  <?rfc subcompact="no" ?>
 
   <front>
-    <title abbrev="Self-published IP Geofeeds">
-    	A Format for Self-published IP Geolocation Feeds
-    </title>
+    <title abbrev="Self-published IP Geofeeds">A Format for Self-published IP
+    Geolocation Feeds</title>
 
-    <author initials="E." surname="Kline" fullname="Erik Kline">
+    <author fullname="Erik Kline" initials="E." surname="Kline">
       <organization>Google Japan</organization>
+
       <address>
         <postal>
           <street>Roppongi 6-10-1, 26th Floor</street>
+
           <city>Minato</city>
+
           <region>Tokyo</region>
+
           <code>106-6126</code>
+
           <country>Japan</country>
         </postal>
 
@@ -70,13 +49,17 @@
       </address>
     </author>
 
-    <author initials="K." surname="Duleba" fullname="Krzysztof Duleba">
+    <author fullname="Krzysztof Duleba" initials="K." surname="Duleba">
       <organization>Google Switzerland GmbH</organization>
+
       <address>
         <postal>
           <street>Brandschenkestrasse 110</street>
+
           <code>8002</code>
+
           <city>Zürich</city>
+
           <country>Switzerland</country>
         </postal>
 
@@ -84,13 +67,17 @@
       </address>
     </author>
 
-    <author initials="Z." surname="Szamonek" fullname="Zoltan Szamonek">
+    <author fullname="Zoltan Szamonek" initials="Z." surname="Szamonek">
       <organization>Google Switzerland GmbH</organization>
+
       <address>
         <postal>
           <street>Brandschenkestrasse 110</street>
+
           <code>8002</code>
+
           <city>Zürich</city>
+
           <country>Switzerland</country>
         </postal>
 
@@ -101,500 +88,442 @@
     <date/>
 
     <abstract>
-      <t>
-This document records a format whereby a network operator can publish a
-mapping of IP address prefixes to simplified geolocation information,
-colloquially termed a geolocation "feed".  Interested parties can poll and
-parse these feeds to update or merge with other geolocation data sources and
-procedures.
-      </t>
-      <t>
-Some technical organizations operating networks that move from one conference
-location to the next have already experimentally published small geolocation
-feeds.  At least one consumer (Google) has incorporated these ad hoc feeds
-into a geolocation data pipeline.
-      </t>
-      <t>
-XXX NOTES TODO
-update geofeed contents (RIPE)
-6280 - 4.1.1 network-based positioning system
+      <t>This document records a format whereby a network operator can publish
+      a mapping of IP address prefixes to simplified geolocation information,
+      colloquially termed a geolocation "feed". Interested parties can poll
+      and parse these feeds to update or merge with other geolocation data
+      sources and procedures. This format intentionally only allows specifying
+       coarse level location.</t>
 
-implicit use policy for LRs
-andy newton's feedback (whois/rdap, dns, ...)
-consumer => Location Recipient
+      <t>Some technical organizations operating networks that move from one
+      conference location to the next have already experimentally published
+      small geolocation feeds. At least one consumer (Google) has incorporated
+      these ad hoc feeds into a geolocation data pipeline, and is using it to
+      allow ISPs to inform them where the prefixes live.</t>
 
-privacy and other work into new #3 section about RM, LG, and LS
-then transmitted LR policy and LR section (current #4)
+      <t>[RFC Ed - Please remove publication: The IETF Meeting network
+      currently publishes a feed in this format at:
+      https://noc.ietf.org/geo/google.csv -- this has significantly cut down
+      on the number of "Gah! Why does the network believe I'm in Montreal,
+      that was last meeting! How am I supposed to find a pub?!"
+      complaints. A number of other meeting networks, including RIPE and ICANN
+      publish this information as well, see below. ]</t>
 
-A1-A4
-Look at PIDF-LO
-specify a media type (application/csv)
-allow repeated fields for multiple regions
+      <t>[ Ed note: Text inside square brackets ([]) is additional background
+      information, answers to frequently asked questions, general musings,
+      etc. They will be removed before publication.]</t>
 
-from London:
-- add use case for more granularity (?)
-- include ISP privacy info URL
-- User can discover if they're in a feed, increases transparency
-- RIPE whois field, RDAP
-- create link relationship, RFC 5988
-
-References:
-- opengeofeed.org
-- https://www.opengeofeed.org/feed/public.csv
-- Mozilla Location Service https://location.services.mozilla.com/
-- https://bugzilla.mozilla.org/show_bug.cgi?id=1042925
-      </t>
+      <t>[ This document is being collaborated on in Github at:
+      https://github.com/google/self-published-geo . The most recent version
+      of the document, open issues, etc should all be available here. The
+      authors (gratefully) accept pull requests ]</t>
     </abstract>
   </front>
 
   <middle>
     <section title="Introduction">
       <section title="Motivation">
-        <t>
-Providers of services over the Internet have grown to depend on best-effort
-geolocation information to improve the user experience.  Locality information
-can aid in directing traffic to the nearest serving location, inferring likely
-native language, and providing additional context for services involving
-search queries.
-        </t>
-        <t>
-When an ISP, for example, changes the location where an IP prefix is
-deployed, services which make use of geolocation information may begin
-to suffer degraded performance. This can lead to customer complaints,
-possibly to the ISP directly. Dissemination of correct geolocation data
-is complicated by the lack of any centralized means to coordinate and
-communicate geolocation information to all interested consumers of the
-data.
-        </t>
-        <t>
-This document records a format whereby a network operator (an ISP, an
-enterprise, or any organization which deems the geolocation of its IP prefixes
-to be of concern) can publish a mapping of IP address prefixes to simplified
-geolocation information, colloquially termed a "geolocation feed".  Interested
-parties can poll and parse these feeds to update or merge with other
-geolocation data sources and procedures.
-        </t>
-        <t>
-Some technical organizations operating networks that move from one conference
-location to the next have already experimentally published small geolocation
-feeds.  At least one consumer (Google) has incorporated these ad hoc feeds
-into a geolocation data pipeline.
-        </t>
+        <t>Providers of services over the Internet have grown to depend on
+        best-effort geolocation information to improve the user experience.
+        Locality information can aid in directing traffic to the nearest
+        serving location, inferring likely native language, and providing
+        additional context for services involving search queries.</t>
+
+        <t>When an ISP, for example, changes the location where an IP prefix
+        is deployed, services which make use of geolocation information may
+        begin to suffer degraded performance. This can lead to customer
+        complaints, possibly to the ISP directly. Dissemination of correct
+        geolocation data is complicated by the lack of any centralized means
+        to coordinate and communicate geolocation information to all
+        interested consumers of the data.</t>
+
+        <t>This document records a format whereby a network operator (an ISP,
+        an enterprise, or any organization which deems the geolocation of its
+        IP prefixes to be of concern) can publish a mapping of IP address
+        prefixes to simplified geolocation information, colloquially termed a
+        "geolocation feed". Interested parties can poll and parse these feeds
+        to update or merge with other geolocation data sources and
+        procedures.</t>
+
+        <t>Some technical organizations operating networks that move from one
+        conference location to the next have already experimentally published
+        small geolocation feeds. At least one consumer (Google) has
+        incorporated these ad hoc feeds into a geolocation data pipeline.</t>
       </section>
 
       <section title="Requirements notation">
-        <t>
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in <xref target="RFC2119"/>.
-        </t>
+        <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+        "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+        document are to be interpreted as described in RFC2119.</t>
       </section>
 
       <section title="Implications of publication">
-        <t>
-This document describes both a format and a mechanism for publishing data,
-with the implication that the owner of the data wishes it to be public.
-Any privacy risk is bounded by the format, and feed publishers MAY omit
-any location field to further protect privacy (see <xref target="spec"/>
-for details about which fields exactly may be omitted).  Feed publishers
-assume the responsibility of determining which data should be made public.
-        </t>
-        <t>
-This proposal does not incorporate a mechanism to communicate acceptable
-use policies for self-published data. Publication itself is inferred as
-a desire by the publisher for the data to be usefully consumed, similar
-to the publication of information like host names, cryptographic keys, and
-SPF records <xref target="RFC4408"/> in the DNS.
-        </t>
+        <t>This document describes both a format and a mechanism for
+        publishing data, with the implication that the owner of the data
+        wishes it to be public. Any privacy risk is bounded by the format, and
+        feed publishers MAY omit any location field to further protect privacy
+        (see <xref target="spec"/> for details about which fields exactly may
+        be omitted). Feed publishers assume the responsibility of determining
+        which data should be made public.</t>
+
+        <t>This proposal does not incorporate a mechanism to communicate
+        acceptable use policies for self-published data. Publication itself is
+        inferred as a desire by the publisher for the data to be usefully
+        consumed, similar to the publication of information like host names,
+        cryptographic keys, and SPF records <xref target="RFC4408"/> in the
+        DNS.</t>
       </section>
     </section>
 
     <section title="Self-published IP geolocation feeds">
-      <t>
-The format described here was developed to address the need of network
-operators to rapidly and usefully share geolocation information changes.
-Originally, there arose a specific case where regional operators found it
-desirable to publish location changes rather than wait for geolocation
-algorithms to "learn" about them.  Later, technical conferences which
-frequently use the same network prefixes advertised from different conference
-locations experimented by publishing geolocation feeds, updated in advance
-of network location changes, in order to better serve conference attendees.
-      </t>
-      <t>
-At its simplest, the mechanism consists of a network operator publishing a
-file (the "geolocation feed"), which contains several text entries, one per
-line.  Each entry is keyed by a unique (within the feed) IP prefix (or single
-IP address) followed by a sequence of network locality attributes to be
-ascribed to the given prefix.
-      </t>
+      <t>The format described here was developed to address the need of
+      network operators to rapidly and usefully share geolocation information
+      changes. Originally, there arose a specific case where regional
+      operators found it desirable to publish location changes rather than
+      wait for geolocation algorithms to "learn" about them. Later, technical
+      conferences which frequently use the same network prefixes advertised
+      from different conference locations experimented by publishing
+      geolocation feeds, updated in advance of network location changes, in
+      order to better serve conference attendees.</t>
+
+      <t>At its simplest, the mechanism consists of a network operator
+      publishing a file (the "geolocation feed"), which contains several text
+      entries, one per line. Each entry is keyed by a unique (within the feed)
+      IP prefix (or single IP address) followed by a sequence of network
+      locality attributes to be ascribed to the given prefix.</t>
 
       <section anchor="spec" title="Specification">
-        <t>
-For operational simplicity, every feed should contain data about all IP
-addresses the provider wants to publish.  Alternatives, like publishing
-only entries for IP addresses whose geolocation data has changed or differ
-from current observed geolocation behavior "at large", are likely to be too
-operationally complex.
-        </t>
-        <t>
-Feeds MUST use UTF-8 <xref target="RFC3629"/> character encoding.
-Text after a '#' character is treated as a comment only and ignored.
-Blank lines are similarly ignored.
-        </t>
-        <t>
-Feeds MUST be in comma separated values format as described in
-<xref target="RFC4180"/>.  Each feed entry is a text line of the form:
-          <figure>
-            <artwork>
+        <t>For operational simplicity, every feed should contain data about
+        all IP addresses the provider wants to publish. Alternatives, like
+        publishing only entries for IP addresses whose geolocation data has
+        changed or differ from current observed geolocation behavior "at
+        large", are likely to be too operationally complex.</t>
+
+        <t>Feeds MUST use UTF-8 <xref target="RFC3629"/> character encoding.
+        Text after a '#' character is treated as a comment only and ignored.
+        Blank lines are similarly ignored.</t>
+
+        <t>Feeds MUST be in comma separated values format as described in
+        <xref target="RFC4180"/>. Each feed entry is a text line of the form:
+        <figure>
+            <artwork><![CDATA[
     ip_prefix,country,region,city,postal_code
-            </artwork>
-          </figure>
-        </t>
-        <t>
-The IP prefix field is REQUIRED, all others are OPTIONAL (can be empty),
-though the requisite minimum number of commas SHOULD be present.
-        </t>
+            ]]></artwork>
+          </figure></t>
+
+        <t>The IP prefix field is REQUIRED, all others are OPTIONAL (can be
+        empty), though the requisite minimum number of commas SHOULD be
+        present.</t>
 
         <section title="Geolocation feed individual entry fields">
           <section title="IP Prefix">
-            <t>
-REQUIRED.  Each IP prefix field MUST be either a single IP address or an
-IP prefix in CIDR notation in conformance with
-<eref target="http://tools.ietf.org/html/rfc4632#section-3.1">section 3.1</eref>
-of <xref target="RFC4632"/> for IPv4 or
-<eref target="http://tools.ietf.org/html/rfc4291#section-2.3">section 2.3</eref>
-of <xref target="RFC4291"/> for IPv6.
-            </t>
-            <t>
-Examples include "192.0.2.1" and "192.0.2.0/24" for IPv4 and "2001:db8::1"
-and "2001:db8::/32" for IPv6.
-            </t>
+            <t>REQUIRED. Each IP prefix field MUST be either a single IP
+            address or an IP prefix in CIDR notation in conformance with <eref
+            target="http://tools.ietf.org/html/rfc4632#section-3.1">section
+            3.1</eref> of <xref target="RFC4632"/> for IPv4 or <eref
+            target="http://tools.ietf.org/html/rfc4291#section-2.3">section
+            2.3</eref> of <xref target="RFC4291"/> for IPv6.</t>
+
+            <t>Examples include "192.0.2.1" and "192.0.2.0/24" for IPv4 and
+            "2001:db8::1" and "2001:db8::/32" for IPv6.</t>
           </section>
 
           <section title="Country">
-            <t>
-OPTIONAL.  The country field, if non-empty, MUST be a 2 letter ISO country
-code conforming to ISO 3166-1 alpha 2 <xref target="ISO.3166.1alpha2"/>.
-Parsers SHOULD treat this field case-insensitively.
-            </t>
-            <t>
-Examples include "US" for the United States, "JP" for Japan, and "PL" for
-Poland.
-            </t>
+            <t>OPTIONAL. The country field, if non-empty, MUST be a 2 letter
+            ISO country code conforming to ISO 3166-1 alpha 2 <xref
+            target="ISO.3166.1alpha2"/>. Parsers SHOULD treat this field
+            case-insensitively.</t>
+
+            <t>Examples include "US" for the United States, "JP" for Japan,
+            and "PL" for Poland.</t>
           </section>
 
           <section title="Region">
-            <t>
-OPTIONAL.  The region field, if non-empty, MUST be a ISO region code
-conforming to ISO 3166-2 <xref target="ISO.3166.2"/>.  Parsers SHOULD
-treat this field case-insensitively.
-            </t>
-            <t>
-Examples include "ID-RI" for the Riau province of Indonesia and "NG-RI" for
-the Rivers province in Nigeria.
-            </t>
+            <t>OPTIONAL. The region field, if non-empty, MUST be a ISO region
+            code conforming to ISO 3166-2 <xref target="ISO.3166.2"/>. Parsers
+            SHOULD treat this field case-insensitively.</t>
+
+            <t>Examples include "ID-RI" for the Riau province of Indonesia and
+            "NG-RI" for the Rivers province in Nigeria.</t>
           </section>
 
           <section title="City">
-            <t>
-OPTIONAL.  The city field, if non-empty, SHOULD be free UTF-8 text,
-excluding the comma (',') character.
-            </t>
-            <t>
-Examples include "Dublin", "New York", and "São Paulo" (specifically
-"S" followed by 0xc3, 0xa3, and "o Paulo").
-            </t>
+            <t>OPTIONAL. The city field, if non-empty, SHOULD be free UTF-8
+            text, excluding the comma (',') character.</t>
+
+            <t>Examples include "Dublin", "New York", and "São Paulo"
+            (specifically "S" followed by 0xc3, 0xa3, and "o Paulo").</t>
           </section>
 
           <section anchor="postal" title="Postal code">
-            <t>
-OPTIONAL.  The postal code field, if non-empty, SHOULD be free UTF-8 text,
-excluding the comma (',') character.  See <xref target="Privacy"/> for some
-discussion of when this field must not be populated.
-            </t>
-            <t>
-Examples include "106-6126" (in Minato ward, Tokyo, Japan).
-            </t>
+            <t>OPTIONAL. The postal code field, if non-empty, SHOULD be free
+            UTF-8 text, excluding the comma (',') character. See <xref
+            target="Privacy"/> for some discussion of when this field must not
+            be populated.</t>
+
+            <t>Examples include "106-6126" (in Minato ward, Tokyo, Japan).</t>
           </section>
         </section>
 
         <section title="Prefixes with no geolocation information">
-          <t>
-Feed publishers may indicate that some IP prefixes should not have any
-associated geolocation information.  It may be that some prefixes under
-their administrative control are reserved, not yet allocated or deployed,
-or are in the process of being redeployed elsewhere and existing
-geolocation information can, from the perspective of the publisher,
-safely be discarded.
-          </t>
-          <t>
-This special case can be indicated by explicitly leaving blank all
-fields which specify any degree of geolocation information.  For
-example:
-          <figure>
-            <artwork>
+          <t>Feed publishers may indicate that some IP prefixes should not
+          have any associated geolocation information. It may be that some
+          prefixes under their administrative control are reserved, not yet
+          allocated or deployed, or are in the process of being redeployed
+          elsewhere and existing geolocation information can, from the
+          perspective of the publisher, safely be discarded.</t>
+
+          <t>This special case can be indicated by explicitly leaving blank
+          all fields which specify any degree of geolocation information. For
+          example: <figure>
+              <artwork><![CDATA[
     127.0.0.0/8,,,,
     224.0.0.0/4,,,,
     240.0.0.0/4,,,,
-            </artwork>
-          </figure>
-          </t>
-          <t>
-Historically, the user-assigned country identifier of "ZZ" had be used
-for this same purpose.  This is not necessarily preferred, and no specific
-interpretation of any of the other user-assigned country codes is
-currently defined.
-          </t>
+            ]]></artwork>
+            </figure></t>
+
+          <t>Historically, the user-assigned country identifier of "ZZ" had be
+          used for this same purpose. This is not necessarily preferred, and
+          no specific interpretation of any of the other user-assigned country
+          codes is currently defined.</t>
         </section>
 
         <section title="Additional parsing requirements">
-          <t>
-Feed entries missing required fields, or having a required field which
-fails to parse correctly MUST be discarded.  It is RECOMMENDED that such
-entries also be logged for further administrative review.
-          </t>
-          <t>
-While publishers SHOULD follow <xref target="RFC5952"/> style for IPv6
-prefix fields, consumers MUST nevertheless accept all valid string
-representations.
-          </t>
-          <t>
-Duplicate IP address or prefix entries MUST be considered an error, and
-consumer implementations SHOULD log the repeated entries for further
-administrative review.  Publishers SHOULD take measures to ensure there is
-one and only one entry per IP address and prefix.
-          </t>
-          <t>
-Feed entries with non-empty optional fields which fail to parse,
-either in part or in full, SHOULD be discarded.  It is RECOMMENDED
-that they also be logged for further administrative review.
-          </t>
-          <t>
-For compatibility with future additional fields a parser MUST ignore any
-fields beyond those it expects.  The data from fields which are expected
-and which parse successfully MUST still be considered valid.
-          </t>
+          <t>Feed entries missing required fields, or having a required field
+          which fails to parse correctly MUST be discarded. It is RECOMMENDED
+          that such entries also be logged for further administrative
+          review.</t>
+
+          <t>While publishers SHOULD follow <xref target="RFC5952"/> style for
+          IPv6 prefix fields, consumers MUST nevertheless accept all valid
+          string representations.</t>
+
+          <t>Duplicate IP address or prefix entries MUST be considered an
+          error, and consumer implementations SHOULD log the repeated entries
+          for further administrative review. Publishers SHOULD take measures
+          to ensure there is one and only one entry per IP address and
+          prefix.</t>
+
+          <t>Feed entries with non-empty optional fields which fail to parse,
+          either in part or in full, SHOULD be discarded. It is RECOMMENDED
+          that they also be logged for further administrative review.</t>
+
+          <t>For compatibility with future additional fields a parser MUST
+          ignore any fields beyond those it expects. The data from fields
+          which are expected and which parse successfully MUST still be
+          considered valid.</t>
         </section>
 
         <section title="Looking up an IP address">
-          <t>
-Multiple entries which constitute nested prefixes are permitted.  Consumers
-SHOULD consider the entry with the longest matching prefix (i.e. the
-"most specific") to be the best matching entry for a given IP address.
-          </t>
+          <t>Multiple entries which constitute nested prefixes are permitted.
+          Consumers SHOULD consider the entry with the longest matching prefix
+          (i.e. the "most specific") to be the best matching entry for a given
+          IP address.</t>
         </section>
       </section>
 
       <section title="Examples">
-        <t>
-Example entries using different IP address formats and describing locations
-at country, region, city and postal code granularity level, respectively:
-          <figure>
-            <artwork>
+        <t>Example entries using different IP address formats and describing
+        locations at country, region, city and postal code granularity level,
+        respectively: <figure>
+            <artwork><![CDATA[
     192.0.2.0/25,US,US-AL,,
     192.0.2.5,US,US-AL,Alabaster,
     192.0.2.128/25,PL,PL-MZ,,02-784
     2001:db8::/32,PL,,,
     2001:db8:cafe::/48,PL,PL-MZ,,02-784
-            </artwork>
-          </figure>
-        </t>
+            ]]></artwork>
+          </figure></t>
 
-        <t>
-Experimentally, RIPE has published geolocation information for their conference
-network prefixes, which change location in accordance with each new event.
-<xref target="GEO_RIPE_NCC"/> at the time of writing contains:
-          <figure>
-            <artwork>
-    193.0.24.0/21,IE,IE-D,Dublin,
-    2001:67c:64::/48,IE,IE-D,Dublin,
-            </artwork>
-          </figure>
-        </t>
+        <t>The IETF network publishes geolocation information for the meeting
+        prefixes, and generally just comment out the last meeting information
+        and append the new meeting information. The <xref target="GEO_IETF"/>
+        at the time of this writing contains:</t>
 
-        <t>
-Similarly, ICANN has published geolocation information for their portable
-conference network prefixes.  <xref target="GEO_ICANN"/> at the time of writing
-contains:
-          <figure>
-            <artwork>
-    199.91.192.0/21,US,US-CA,Los Angeles,
-    2620:f:8000::/48,US,US-CA,Los Angeles,
-            </artwork>
-          </figure>
-        </t>
+        <t><figure>
+            <artwork><![CDATA[# IETF 104, March 2019 - Prague, CZ.
+# Note that Prague changed from CZ-PR to CZ-10 2016-11-15 - https://www.iso.org/obp/ui/#iso:code:3166:CZ
+130.129.0.0/16,CZ,CZ-10,Prague,
+2001:df8::/32,CZ,CZ-10,Prague,
+31.133.128.0/18,CZ,CZ-10,Prague,
+31.130.224.0/20,CZ,CZ-10,Prague,
+2001:67c:1230::/46,CZ,CZ-10,Prague,
+2001:67c:370::/48,CZ,CZ-10,Prague,]]></artwork>
+          </figure></t>
 
-        <t>
-Furthermore, it is worth noting that the geolocation data of SixXS users,
-already available at whois.sixxs.net, is now also accessible in the format
-described here (see <xref target="GEO_SIXXS"/>).  This can be particularly
-useful where tunnel broker networks <xref target="RFC3053"/> are concerned as:
-          <list style="symbols">
-            <t>
-the geolocation attributes of users with neighboring prefixes can be quite
-different and therefore not easily aggregated, and
-            </t>
-            <t>
-attempting to learn this data by statistical analysis can be complicated by
-the likely low number of samples for any given user, making satisfactory
-statistical confidence difficult to achieve.
-            </t>
-          </list>
-        </t>
+        <t>Experimentally, RIPE has published geolocation information for
+        their conference network prefixes, which change location in accordance
+        with each new event. <xref target="GEO_RIPE_NCC"/> at the time of
+        writing contains: <figure>
+            <artwork><![CDATA[
+   193.0.24.0/21,IS,IS-1,Reykjavík,
+   2001:67c:64::/48,IS,IS-1,Reykjavík,      ]]></artwork>
+          </figure></t>
+
+        <t>Similarly, ICANN has published geolocation information for their
+        portable conference network prefixes. <xref target="GEO_ICANN"/> at
+        the time of writing contains: <figure>
+            <artwork><![CDATA[
+   199.91.192.0/21,ES,ES-CT,Barcelona
+   2620:f:8000::/48,ES,ES-CT,Barcelona   ]]></artwork>
+          </figure></t>
+
+        <t>A longer example is the <xref target="GEO_Google"/> Google Corp
+        Geofeed, which lists the geo-location information for Google coroprate
+        offices.</t>
+
+        <t>Furthermore, it is worth noting that the geolocation data of SixXS
+        users, already available at whois.sixxs.net, is now also accessible in
+        the format described here (see <xref target="GEO_SIXXS"/>). This can
+        be particularly useful where tunnel broker networks <xref
+        target="RFC3053"/> are concerned as: <list style="symbols">
+            <t>the geolocation attributes of users with neighboring prefixes
+            can be quite different and therefore not easily aggregated,
+            and</t>
+
+            <t>attempting to learn this data by statistical analysis can be
+            complicated by the likely low number of samples for any given
+            user, making satisfactory statistical confidence difficult to
+            achieve.</t>
+          </list></t>
       </section>
 
       <section title="Proposed extensions">
-        <t>
-Already some discussions have resulted in proposed extensions.  While the
-purpose of this document is principally to record existing implementation
-details, it may be that there is a larger desire to publish other "network
-attributes" in a similar manner.  One such network attribute, "delegation
-size", is not currently implemented but the state of the proposed
-extension is recorded here to demonstrate the flexibility required of
-parser implementations.
-        </t>
-        <t>
-The following have been only informally discussed and are not in use at the
-time of writing.
-        </t>
+        <t>Already some discussions have resulted in proposed extensions.
+        While the purpose of this document is principally to record existing
+        implementation details, it may be that there is a larger desire to
+        publish other "network attributes" in a similar manner. One such
+        network attribute, "delegation size", is not currently implemented but
+        the state of the proposed extension is recorded here to demonstrate
+        the flexibility required of parser implementations.</t>
+
+        <t>The following have been only informally discussed and are not in
+        use at the time of writing.</t>
 
         <section title="Delegation size">
-          <t>
-OPTIONAL.  A publisher may optionally communicate the average delegated
-prefix size for subnetworks within the IP prefix of this entry.  For a network
-operator this can be used to help consumers distinguish IP prefixes among
-various use types such as residential prefixes, allocations to businesses,
-or data center customer allocations.
-          </t>
-          <t>
-Non-empty strings MUST be of the form required for CIDR notation suffixes,
-i.e. "/" followed by the integer prefix length of the expected allocation
-to the subnetworks from within the entry's prefix.  In the absence of data
-to the contrary, it is common to assume that leaf networks may be delegated
-a prefix ranging from /24 to /32 in IPv4 and /48 to /64 in IPv6.  Default
-assumptions about delegation size are left to the consumer's implementation.
-          </t>
-          <t>
-Examples for IPv6 include "/48", "/56", "/60", and "/64".
-          </t>
+          <t>OPTIONAL. A publisher may optionally communicate the average
+          delegated prefix size for subnetworks within the IP prefix of this
+          entry. For a network operator this can be used to help consumers
+          distinguish IP prefixes among various use types such as residential
+          prefixes, allocations to businesses, or data center customer
+          allocations.</t>
+
+          <t>Non-empty strings MUST be of the form required for CIDR notation
+          suffixes, i.e. "/" followed by the integer prefix length of the
+          expected allocation to the subnetworks from within the entry's
+          prefix. In the absence of data to the contrary, it is common to
+          assume that leaf networks may be delegated a prefix ranging from /24
+          to /32 in IPv4 and /48 to /64 in IPv6. Default assumptions about
+          delegation size are left to the consumer's implementation.</t>
+
+          <t>Examples for IPv6 include "/48", "/56", "/60", and "/64".</t>
         </section>
+
         <section title="Alternate format">
-          <t>
-In order to more flexibly support future extensions, use of a more
-expressive feed format has been suggested.  Use of JavaScript Object
-Notation (JSON, <xref target="RFC4627"/>), specifically, has been
-discussed.  However, at the time of writing no such specification nor
-implementation exists.
-          </t>
+          <t>In order to more flexibly support future extensions, use of a
+          more expressive feed format has been suggested. Use of JavaScript
+          Object Notation (JSON, <xref target="RFC4627"/>), specifically, has
+          been discussed. However, at the time of writing no such
+          specification nor implementation exists.</t>
         </section>
       </section>
     </section>
 
     <section anchor="consumers"
              title="Consuming self-published IP geolocation feeds">
-      <t>
-Consumers MAY treat published feed data as a hint only and MAY choose
-to prefer other sources of geolocation information for any given IP prefix.
-Regardless of a consumer's stance with respect to a given published feed,
-there are some points of note for sensibly and effectively consuming
-published feeds.
-      </t>
+      <t>Consumers MAY treat published feed data as a hint only and MAY choose
+      to prefer other sources of geolocation information for any given IP
+      prefix. Regardless of a consumer's stance with respect to a given
+      published feed, there are some points of note for sensibly and
+      effectively consuming published feeds.</t>
 
       <section title="Feed integrity">
-        <t>
-The integrity of published information SHOULD be protected by securing the
-means of publication, for example by using HTTP over TLS
-<xref target="RFC2818"/>.  Whenever possible, consumers SHOULD prefer
-retrieving geolocation feeds in a manner that guarantees integrity of the feed.
-        </t>
+        <t>The integrity of published information SHOULD be protected by
+        securing the means of publication, for example by using HTTP over TLS
+        <xref target="RFC2818"/>. Whenever possible, consumers SHOULD prefer
+        retrieving geolocation feeds in a manner that guarantees integrity of
+        the feed.</t>
       </section>
 
       <section title="Verification of authority">
-        <t>
-Consumers of self-published IP geolocation feeds SHOULD perform some form
-of verification that the publisher is in fact authoritative for the
-addresses in the feed.  The actual means of verification is likely dependent
-upon the way in which the feed is discovered.  Ad hoc shared URIs, for example,
-will likely require an ad hoc verification process.  Future automated means of
-feed discovery SHOULD have an accompanying automated means of verification.
-        </t>
-        <t>
-A consumer MUST only trust geolocation information for IP addresses or prefixes
-for which the publisher has been verified as administratively authoritative.
-All other geolocation feed entries MUST be ignored and SHOULD be logged for
-further administrative review.
-        </t>
+        <t>Consumers of self-published IP geolocation feeds SHOULD perform
+        some form of verification that the publisher is in fact authoritative
+        for the addresses in the feed. The actual means of verification is
+        likely dependent upon the way in which the feed is discovered. Ad hoc
+        shared URIs, for example, will likely require an ad hoc verification
+        process. Future automated means of feed discovery SHOULD have an
+        accompanying automated means of verification.</t>
+
+        <t>A consumer MUST only trust geolocation information for IP addresses
+        or prefixes for which the publisher has been verified as
+        administratively authoritative. All other geolocation feed entries
+        MUST be ignored and SHOULD be logged for further administrative
+        review.</t>
       </section>
 
       <section title="Verification of accuracy">
-        <t>
-Errors and inaccuracies may occur at many levels, and publication and
-consumption of geolocation data are no exceptions.  To the extent practical
-consumers SHOULD take steps to verify the accuracy of published locality.
-Verification methodology, resolution of discrepancies, and preference for
-alternative sources of data are left to the discretion of the feed consumer.
-        </t>
-        <t>
-Consumers SHOULD decide on discrepancy thresholds and SHOULD flag for
-administrative review feed entries which exceed set thresholds.
-        </t>
+        <t>Errors and inaccuracies may occur at many levels, and publication
+        and consumption of geolocation data are no exceptions. To the extent
+        practical consumers SHOULD take steps to verify the accuracy of
+        published locality. Verification methodology, resolution of
+        discrepancies, and preference for alternative sources of data are left
+        to the discretion of the feed consumer.</t>
+
+        <t>Consumers SHOULD decide on discrepancy thresholds and SHOULD flag
+        for administrative review feed entries which exceed set
+        thresholds.</t>
       </section>
 
       <section title="Refreshing feed information">
-        <t>
-As a publisher can change geolocation data at any time and without
-notification consumers SHOULD implement mechanisms to periodically refresh
-local copies of feed data.  In the absence of any other refresh timing
-information it is recommended that consumers SHOULD refresh feeds no less
-often than weekly.
-        </t>
-        <t>
-For feeds available via HTTPS (or HTTP), the publisher MAY communicate
-refresh timing information by means of the standard HTTP expiration model
-(<eref target="http://tools.ietf.org/html/rfc2616#section-13.2">section
-13.2</eref> of <xref target="RFC2616"/>).  Specifically, publishers can
-include either an
-<eref target="http://tools.ietf.org/html/rfc2616#section-14.21">Expires
-header</eref> or a
-<eref target="http://tools.ietf.org/html/rfc2616#section-14.9">Cache-Control
-header</eref> specifying the max-age.  Where practical, consumers SHOULD
-refresh feed information before the expiry time is reached.
-        </t>
+        <t>As a publisher can change geolocation data at any time and without
+        notification consumers SHOULD implement mechanisms to periodically
+        refresh local copies of feed data. In the absence of any other refresh
+        timing information it is recommended that consumers SHOULD refresh
+        feeds no less often than weekly.</t>
+
+        <t>For feeds available via HTTPS (or HTTP), the publisher MAY
+        communicate refresh timing information by means of the standard HTTP
+        expiration model (<eref
+        target="http://tools.ietf.org/html/rfc2616#section-13.2">section
+        13.2</eref> of <xref target="RFC2616"/>). Specifically, publishers can
+        include either an <eref
+        target="http://tools.ietf.org/html/rfc2616#section-14.21">Expires
+        header</eref> or a <eref
+        target="http://tools.ietf.org/html/rfc2616#section-14.9">Cache-Control
+        header</eref> specifying the max-age. Where practical, consumers
+        SHOULD refresh feed information before the expiry time is reached.</t>
       </section>
     </section>
 
     <section anchor="Privacy" title="Privacy Considerations">
-      <t>
-Publishers of geolocation feeds are advised to have fully considered any
-and all privacy implications of the disclosure of such information for the
-users of the described networks prior to publication.  A thorough
-comprehension of the
-<eref target="http://tools.ietf.org/html/rfc6772#section-13">security
-considerations</eref> of a chosen geolocation policy is highly recommended,
-including an understanding of some of the
-<eref target="http://tools.ietf.org/html/rfc6772#section-13.5">limitations
-of information obscurity</eref> (see also <xref target="RFC6772"/>).
-      </t>
-      <t>
-As noted in <xref target="spec"/>, each location field in an entry is
-optional, in order to support expressing only the level of specificity which
-the publisher has deemed acceptable.  There is no requirement that the level
-of specificity be consistent across all entries within a feed.
-In particular, the Postal Code field (<xref target="postal"/>) can provide
-very specific geolocation, sometimes within a building.  Such specific
-Postal Code values MUST NOT be published in geo feeds without the consent
-of the parties being located.
-      </t>
+      <t>Publishers of geolocation feeds are advised to have fully considered
+      any and all privacy implications of the disclosure of such information
+      for the users of the described networks prior to publication. A thorough
+      comprehension of the <eref
+      target="http://tools.ietf.org/html/rfc6772#section-13">security
+      considerations</eref> of a chosen geolocation policy is highly
+      recommended, including an understanding of some of the <eref
+      target="http://tools.ietf.org/html/rfc6772#section-13.5">limitations of
+      information obscurity</eref> (see also <xref target="RFC6772"/>).</t>
+
+      <t>As noted in <xref target="spec"/>, each location field in an entry is
+      optional, in order to support expressing only the level of specificity
+      which the publisher has deemed acceptable. There is no requirement that
+      the level of specificity be consistent across all entries within a feed.
+      In particular, the Postal Code field (<xref target="postal"/>) can
+      provide very specific geolocation, sometimes within a building. Such
+      specific Postal Code values MUST NOT be published in geo feeds without
+      the consent of the parties being located.</t>
     </section>
 
     <section title="Relation to other work">
-      <t>
-While not originally done in conjunction with the <xref target="GEOPRIV"/>
-working group, Richard Barnes observed that this work is nevertheless
-consistent with that which the group has defined, both for address format and
-for privacy.  The data elements in geolocation feeds are equivalent to the
-following XML structure (vis. <xref target="RFC5139"/>):
-        <figure>
+      <t>While not originally done in conjunction with the <xref
+      target="GEOPRIV"/> working group, Richard Barnes observed that this work
+      is nevertheless consistent with that which the group has defined, both
+      for address format and for privacy. The data elements in geolocation
+      feeds are equivalent to the following XML structure (vis. <xref
+      target="RFC5139"/>): <figure>
           <artwork><![CDATA[
     <civicAddress>
       <country>country</country>
@@ -603,14 +532,12 @@ following XML structure (vis. <xref target="RFC5139"/>):
       <PC>postal_code</PC>
     </civicAddress>
           ]]></artwork>
-        </figure>
-      </t>
-      <t>
-Providing geolocation information to this granularity is equivalent to the
-following privacy policy (vis. the definition of the
-<eref target="http://tools.ietf.org/html/rfc6772#section-6.5.1">
-'building'</eref> level of disclosure):
-        <figure>
+        </figure></t>
+
+      <t>Providing geolocation information to this granularity is equivalent
+      to the following privacy policy (vis. the definition of the <eref
+      target="http://tools.ietf.org/html/rfc6772#section-6.5.1">
+      'building'</eref> level of disclosure): <figure>
           <artwork><![CDATA[
     <ruleset>
       <rule>
@@ -624,332 +551,324 @@ following privacy policy (vis. the definition of the
       </rule>
     </ruleset>
           ]]></artwork>
-        </figure>
-      </t>
+        </figure></t>
     </section>
 
     <section anchor="Security" title="Security Considerations">
-      <t>
-As there is no true security in the obscurity of the location of any given
-IP address, self-publication of this data fundamentally opens no new attack
-vectors.  For publishers, self-published data merely increases the ease with
-which such location data might be exploited.
-      </t>
-      <t>
-For consumers, feed retrieval processes may receive input from potentially
-hostile sources (e.g. in the event of hijacked traffic).  As such, proper
-input validation and defense measures MUST be taken.
-      </t>
-      <t>
-Similarly, consumers who do not perform sufficient verification of published
-data bear the same risks as from other forms of geolocation configuration
-errors.
-     </t>
+      <t>As there is no true security in the obscurity of the location of any
+      given IP address, self-publication of this data fundamentally opens no
+      new attack vectors. For publishers, self-published data merely increases
+      the ease with which such location data might be exploited.</t>
+
+      <t>For consumers, feed retrieval processes may receive input from
+      potentially hostile sources (e.g. in the event of hijacked traffic). As
+      such, proper input validation and defense measures MUST be taken.</t>
+
+      <t>Similarly, consumers who do not perform sufficient verification of
+      published data bear the same risks as from other forms of geolocation
+      configuration errors.</t>
     </section>
 
     <section title="Finding self-published IP geolocation feeds">
-      <t>
-The issue of finding, and later verifying, geolocation feeds is not
-formally specified in this document.  At this time, only ad hoc feed
-discovery and verification has a modicum of established practice (see below).
-Regardless, both the ad hoc mechanics and a few proposed but not yet
-implemented alternatives are discussed.
-      </t>
+      <t>The issue of finding, and later verifying, geolocation feeds is not
+      formally specified in this document. At this time, only ad hoc feed
+      discovery and verification has a modicum of established practice (see
+      below). Regardless, both the ad hoc mechanics and a few proposed but not
+      yet implemented alternatives are discussed.</t>
 
       <section title="Ad hoc 'well known' URIs">
-        <t>
-To date, geolocation feeds have been shared informally in the form of HTTPS
-URIs exchanged in email threads.  The two example URIs documented above
-describe networks that change locations periodically, the operators and
-operational practices of which are well known within their respective
-technical communities.
-        </t>
-        <t>
-The contents of the feeds are verified by a similarly ad hoc process
-including:
-          <list style="symbols">
-            <t>
-personal knowledge of the parties involved in the exchange, and
-            </t>
-            <t>
-comparison of feed-advertised prefixes with the BGP-advertised prefixes
-of Autonomous System Numbers known to be operated by the publishers.
-            </t>
-          </list>
-        </t>
-        <t>
-Ad hoc mechanisms, while useful for early experimentation by producers and
-consumers, are unlikely to be adequate for long-term, widespread use by
-multiple parties.  Future versions of any such self-published geolocation
-feed mechanism SHOULD address scalability concerns by defining a means
-for automated discovery and verification of operational authority of
-advertised prefixes.
-        </t>
+        <t>To date, geolocation feeds have been shared informally in the form
+        of HTTPS URIs exchanged in email threads. The two example URIs
+        documented above describe networks that change locations periodically,
+        the operators and operational practices of which are well known within
+        their respective technical communities.</t>
+
+        <t>The contents of the feeds are verified by a similarly ad hoc
+        process including: <list style="symbols">
+            <t>personal knowledge of the parties involved in the exchange,
+            and</t>
+
+            <t>comparison of feed-advertised prefixes with the BGP-advertised
+            prefixes of Autonomous System Numbers known to be operated by the
+            publishers.</t>
+          </list></t>
+
+        <t>Ad hoc mechanisms, while useful for early experimentation by
+        producers and consumers, are unlikely to be adequate for long-term,
+        widespread use by multiple parties. Future versions of any such
+        self-published geolocation feed mechanism SHOULD address scalability
+        concerns by defining a means for automated discovery and verification
+        of operational authority of advertised prefixes.</t>
       </section>
 
       <section title="Using public databases of network authority">
-        <t>
-One possibility for enabling automation would be publication of feed URIs as
-a well-known attribute in public databases of network authority, e.g. the
-WHOIS service (<xref target="RFC3912"/>) operated by RIRs.  Verification
-may be performed if the same or similarly authoritative service provides the
-identical feed URI for queries for each CIDR prefix in the geolocation feed.
-        </t>
-        <t>
-The burden of serving this data to all interested consumers, especially the
-load imposed by any verification process, is not yet known.  The anticipation
-of additional operational burden on the public resource of record (the
-database of network authority) is however a noted concern.
-        </t>
+        <t>One possibility for enabling automation would be publication of
+        feed URIs as a well-known attribute in public databases of network
+        authority, e.g. the WHOIS service (<xref target="RFC3912"/>) operated
+        by RIRs. Verification may be performed if the same or similarly
+        authoritative service provides the identical feed URI for queries for
+        each CIDR prefix in the geolocation feed.</t>
+
+        <t>The burden of serving this data to all interested consumers,
+        especially the load imposed by any verification process, is not yet
+        known. The anticipation of additional operational burden on the public
+        resource of record (the database of network authority) is however a
+        noted concern.</t>
       </section>
 
       <section title="Using 'reverse' DNS with NAPTR records">
-        <t>
-Another possibility for automating the location and verification of a
-geolocation feed is to incorporate feed URIs into the DNS, specifically the
-in-addr.arpa and ip6.arpa portions of the DNS hierarchy.  A suitably formatted
-query for a NAPTR (<xref target="RFC3403"/>) record, or more specifically a
-U-NAPTR (<xref target="RFC4848"/>) record, could yield a transformation to
-a geolocation feed URI.
-        </t>
-        <t>
-For example, assuming a purely theoretical service name of "x-geofeed",
-a 'reverse' DNS zone might contain a record of the form:
-          <figure>
-            <artwork>
+        <t>Another possibility for automating the location and verification of
+        a geolocation feed is to incorporate feed URIs into the DNS,
+        specifically the in-addr.arpa and ip6.arpa portions of the DNS
+        hierarchy. A suitably formatted query for a NAPTR (<xref
+        target="RFC3403"/>) record, or more specifically a U-NAPTR (<xref
+        target="RFC4848"/>) record, could yield a transformation to a
+        geolocation feed URI.</t>
+
+        <t>For example, assuming a purely theoretical service name of
+        "x-geofeed", a 'reverse' DNS zone might contain a record of the form:
+        <figure>
+            <artwork><![CDATA[
     ;;       order pref flags
     IN NAPTR 200   10   "u"    "x-geofeed"        ( ; service
                                                     ; regexp
                                "!.*!https://example.com/ipgeo.csv!"
                                ""                   ; replacement
                                )
-            </artwork>
-          </figure>
-        </t>
-        <t>
-Attempts to locate the geolocation feed for a given IP address would begin by
-querying directly for a NAPTR record associated with the address's PTR-style
-name. For example, 192.0.2.4 and 2001:db8::6 would cause a NAPTR record
-request to be issued for "4.2.0.192.in-addr.arpa" and
-"6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
-respectively.
-        </t>
-        <t>
-If no such record exists one further NAPTR query for the fully qualified
-domain name of the SOA record in the authority section of the response to the
-previous query would be performed ("2.0.192.in-addr.arpa" and
-"d.0.1.0.0.2.ip6.arpa" in the examples above).
-        </t>
-        <t>
-If one or more NAPTR records exist for the full PTR-style name but none of
-them are for the required service name (e.g. "x-geofeed"), then likely no SOA
-will be returned as a hint for subsequent queries.  In this case
-implementations would need to first explicitly query for an SOA record for the
-full PTR-style name, and then query for a NAPTR record of the SOA in the
-response (assuming it differs from the previously queried name).
-        </t>
-        <t>
-Any successfully located feed URIs could then be processed as outlined by this
-document.
-        </t>
-        <t>
-Verification of the contents of a feed would proceed in essentially the same
-way.  CIDR prefixes may be verified by constructing a query for any single
-address (at random) within the prefix and proceeding as above.  While not
-strictly provably correct (in cases where a publisher has delegated some
-portion of the advertised prefix but not excluded it from its feed), it may
-nevertheless suffice for operational purposes, especially if a low-impact
-on-going verification of observed client IP addresses is implemented, to
-(eventually) catch any oversights.
-        </t>
-        <t>
-This mode is untested and may prove impractical.  However, the operational
-burden is more closely located with those wishing and willing to bear it,
-i.e. the publishers who would likely handle serving in-addr.arpa and
-ip6.arpa for the IP prefixes under their authority.
-        </t>
+            ]]></artwork>
+          </figure></t>
+
+        <t>Attempts to locate the geolocation feed for a given IP address
+        would begin by querying directly for a NAPTR record associated with
+        the address's PTR-style name. For example, 192.0.2.4 and 2001:db8::6
+        would cause a NAPTR record request to be issued for
+        "4.2.0.192.in-addr.arpa" and
+        "6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa",
+        respectively.</t>
+
+        <t>If no such record exists one further NAPTR query for the fully
+        qualified domain name of the SOA record in the authority section of
+        the response to the previous query would be performed
+        ("2.0.192.in-addr.arpa" and "d.0.1.0.0.2.ip6.arpa" in the examples
+        above).</t>
+
+        <t>If one or more NAPTR records exist for the full PTR-style name but
+        none of them are for the required service name (e.g. "x-geofeed"),
+        then likely no SOA will be returned as a hint for subsequent queries.
+        In this case implementations would need to first explicitly query for
+        an SOA record for the full PTR-style name, and then query for a NAPTR
+        record of the SOA in the response (assuming it differs from the
+        previously queried name).</t>
+
+        <t>Any successfully located feed URIs could then be processed as
+        outlined by this document.</t>
+
+        <t>Verification of the contents of a feed would proceed in essentially
+        the same way. CIDR prefixes may be verified by constructing a query
+        for any single address (at random) within the prefix and proceeding as
+        above. While not strictly provably correct (in cases where a publisher
+        has delegated some portion of the advertised prefix but not excluded
+        it from its feed), it may nevertheless suffice for operational
+        purposes, especially if a low-impact on-going verification of observed
+        client IP addresses is implemented, to (eventually) catch any
+        oversights.</t>
+
+        <t>This mode is untested and may prove impractical. However, the
+        operational burden is more closely located with those wishing and
+        willing to bear it, i.e. the publishers who would likely handle
+        serving in-addr.arpa and ip6.arpa for the IP prefixes under their
+        authority.</t>
       </section>
     </section>
 
     <section title="Acknowledgements">
-      <t>
-The authors would like to express their gratitude to reviewers and early
-implementers, including but not limited to
-
-    Mikael Abrahamsson,
-    Ray Bellis,
-    John Bond,
-    Alissa Cooper,
-    Andras Erdei,
-    Marco Hogewoning,
-    Mike Joseph,
-    Warren Kumari,
-    Menno Schepers,
-    Justyna Sidorska,
-    Pim van Pelt,
-and
-    Bjoern A. Zeeb.
-
-Richard L. Barnes in particular contributed substantial review, text, and
-advice.
-      </t>
+      <t>The authors would like to express their gratitude to reviewers and
+      early implementers, including but not limited to Mikael Abrahamsson, Ray
+      Bellis, John Bond, Alissa Cooper, Andras Erdei, Marco Hogewoning, Mike
+      Joseph, Warren Kumari, Menno Schepers, Justyna Sidorska, Pim van Pelt,
+      and Bjoern A. Zeeb. Richard L. Barnes in particular contributed
+      substantial review, text, and advice.</t>
     </section>
   </middle>
 
   <back>
-      <references title="Normative References">
-&rfc2119;
+    <references title="Normative References">
+      <reference anchor="ISO.3166.1alpha2"
+                 target="http://www.iso.org/iso/home/standards/country_codes/iso-3166-1_decoding_table.htm">
+        <front>
+          <title>ISO 3166-1 decoding table</title>
 
-&rfc2616;
+          <author fullname="ISO 3166 Maintenance agency">
+            <organization abbrev="ISO">International Organization for
+            Standardization</organization>
+          </author>
 
-&rfc3629;
+          <date/>
+        </front>
+      </reference>
 
-&rfc4180;
+      <?rfc include='reference.RFC.2616.xml'?>
 
-&rfc4291;
+      <?rfc include='reference.RFC.3629.xml'?>
 
-&rfc4632;
+      <?rfc include='reference.RFC.4180.xml'?>
 
-<reference
- anchor="ISO.3166.1alpha2"
- target="http://www.iso.org/iso/home/standards/country_codes/iso-3166-1_decoding_table.htm">
-  <front>
-    <title>ISO 3166-1 decoding table</title>
-    <author fullname="ISO 3166 Maintenance agency">
-      <organization abbrev="ISO">
-International Organization for Standardization
-      </organization>
-    </author>
-    <date/>
-  </front>
-</reference>
+      <?rfc include='reference.RFC.4291.xml'?>
 
-<reference
- anchor="ISO.3166.2"
- target="http://www.iso.org/iso/home/standards/country_codes.htm#2012_iso3166-2"
- >
-  <front>
-    <title>ISO 3166-2:2007</title>
-    <author fullname="ISO 3166 Maintenance agency">
-      <organization abbrev="ISO">
-International Organization for Standardization
-      </organization>
-    </author>
-    <date/>
-  </front>
-</reference>
-      </references>
+      <?rfc include='reference.RFC.4632.xml'?>
 
-      <references title="Informative References">
-&rfc2818;
+      <reference anchor="ISO.3166.2"
+                 target="http://www.iso.org/iso/home/standards/country_codes.htm#2012_iso3166-2">
+        <front>
+          <title>ISO 3166-2:2007</title>
 
-&rfc3053;
+          <author fullname="ISO 3166 Maintenance agency">
+            <organization abbrev="ISO">International Organization for
+            Standardization</organization>
+          </author>
 
-&rfc3403;
+          <date/>
+        </front>
+      </reference>
+    </references>
 
-&rfc3912;
+    <references title="Informative References">
+      <?rfc include='reference.RFC.2818.xml'?>
 
-&rfc4408;
+      <?rfc include='reference.RFC.3053.xml'?>
 
-&rfc4627;
+      <?rfc include='reference.RFC.3403.xml'?>
 
-&rfc4848;
+      <?rfc include='reference.RFC.3912.xml'?>
 
-&rfc5139;
+      <?rfc include='reference.RFC.4408.xml'?>
 
-&rfc5952;
+      <?rfc include='reference.RFC.4627.xml'?>
 
-&rfc6772;
+      <?rfc include='reference.RFC.4848.xml'?>
 
-<reference target="https://meetings.ripe.net/geo/google.csv"
-           anchor="GEO_RIPE_NCC">
-  <front>
-    <title>RIPE NCC Meeting Geolocation Data</title>
-    <author fullname="Menno Schepers" initials="M." surname="Schepers">
-      <organization abbrev="RIPE NCC">
-Réseaux IP Européens Network Coordination Centre
-      </organization>
-    </author>
-    <date/>
-  </front>
-</reference>
+      <?rfc include='reference.RFC.5139.xml'?>
 
-<reference target="https://registration.icann.org/geo/google.csv"
-           anchor="GEO_ICANN">
-  <front>
-    <title>ICANN Meeting Geolocation Data</title>
-    <author>
-      <organization abbrev="ICANN">
-Internet Corporation For Assigned Names and Numbers
-      </organization>
-    </author>
-    <date/>
-  </front>
-</reference>
+      <?rfc include='reference.RFC.5952.xml'?>
 
-<reference target="https://www.sixxs.net/export/google/"
-           anchor="GEO_SIXXS">
-  <front>
-    <title>SixXS Geolocation Data</title>
-    <author fullname="Pim van Pelt" initials="P." surname="van Pelt">
-      <organization abbrev="SixXS">
-SixXS IPv6 Deployment and Tunnel Broker
-      </organization>
-    </author>
-    <date/>
-  </front>
-</reference>
+      <?rfc include='reference.RFC.6772.xml'?>
 
-<reference target="http://datatracker.ietf.org/wg/geopriv/"
-           anchor="GEOPRIV">
-  <front>
-    <title>IETF geopriv Working Group</title>
-    <author>
-      <organization abbrev="IETF">
-Internet Engineering Task Force
-      </organization>
-    </author>
-    <date/>
-  </front>
-</reference>
+      <reference anchor="GEO_IETF"
+                 target="https://noc.ietf.org/geo/google.csv">
+        <front>
+          <title>IETF Meeting Network Geolocation Data</title>
 
-<reference target="http://code.google.com/p/ipaddr-py/"
-           anchor="IPADDR_PY">
-  <front>
-    <title>Python IP address manipulation library</title>
-    <author fullname="Mike Shields" initials="M." surname="Shields">
-      <organization abbrev="Google">
-Google Inc.
-      </organization>
-    </author>
-    <author fullname="Peter Moody" initials="P." surname="Moody">
-      <organization abbrev="Google">
-Google Inc.
-      </organization>
-    </author>
-    <date/>
-  </front>
-</reference>
-      </references>
+          <author fullname="Warren" initials="A." surname="Kumari">
+            <organization abbrev="IETF NOC">Internet Engineering Task Force
+            (IETF) NOC</organization>
+          </author>
 
-      <section title="Sample Python validation code">
-        <t>
-Included here is a simple format validator in Python for self-published ipgeo
-feeds.  This tool reads CSV data in the self-published ipgeo feed format from
-the standard input and performs basic validation.  It is intended for
-use by feed publishers before launching a feed.  Note that this validator does
-not verify the uniqueness of every IP prefix entry within the feed as a whole,
-but only verifies the syntax of each single line from within the feed.  A
-complete validator MUST also ensure IP prefix uniqueness.
-        </t>
-        <t>
-The main source file "ipgeo_feed_validator.py" follows.  It requires use of the
-open source ipaddr Python library for IP address and CIDR parsing and
-validation <xref target="IPADDR_PY"/>.
-        </t>
-        <t>
-          <figure>
-            <artwork><![CDATA[
+          <date/>
+        </front>
+      </reference>
+
+      <reference anchor="GEO_RIPE_NCC"
+                 target="https://meetings.ripe.net/geo/google.csv">
+        <front>
+          <title>RIPE NCC Meeting Geolocation Data</title>
+
+          <author fullname="Menno Schepers" initials="M." surname="Schepers">
+            <organization abbrev="RIPE NCC">R&eacute;seaux IP Europ&eacute;ens
+            Network Coordination Centre</organization>
+          </author>
+
+          <date/>
+        </front>
+      </reference>
+
+      <reference anchor="GEO_ICANN"
+                 target="https://registration.icann.org/geo/google.csv">
+        <front>
+          <title>ICANN Meeting Geolocation Data</title>
+
+          <author>
+            <organization abbrev="ICANN">Internet Corporation For Assigned
+            Names and Numbers</organization>
+          </author>
+
+          <date/>
+        </front>
+      </reference>
+
+      <reference anchor="GEO_Google"
+                 target="https://www.gstatic.com/geofeed/corp_external">
+        <front>
+          <title>Google Corp Geofeed</title>
+	  <author>
+	    <organization>Google, LLC</organization>
+	  </author>
+
+          <date/>
+        </front>
+      </reference>
+
+      <reference anchor="GEO_SIXXS"
+                 target="https://www.sixxs.net/export/google/">
+        <front>
+          <title>SixXS Geolocation Data</title>
+
+          <author fullname="Pim van Pelt" initials="P." surname="van Pelt">
+            <organization abbrev="SixXS">SixXS IPv6 Deployment and Tunnel
+            Broker</organization>
+          </author>
+
+          <date/>
+        </front>
+      </reference>
+
+      <reference anchor="GEOPRIV"
+                 target="http://datatracker.ietf.org/wg/geopriv/">
+        <front>
+          <title>IETF geopriv Working Group</title>
+
+          <author>
+            <organization abbrev="IETF">Internet Engineering Task
+            Force</organization>
+          </author>
+
+          <date/>
+        </front>
+      </reference>
+
+      <reference anchor="IPADDR_PY"
+                 target="http://code.google.com/p/ipaddr-py/">
+        <front>
+          <title>Python IP address manipulation library</title>
+
+          <author fullname="Mike Shields" initials="M." surname="Shields">
+            <organization abbrev="Google">Google Inc.</organization>
+          </author>
+
+          <author fullname="Peter Moody" initials="P." surname="Moody">
+            <organization abbrev="Google">Google Inc.</organization>
+          </author>
+
+          <date/>
+        </front>
+      </reference>
+    </references>
+
+    <section title="Sample Python validation code">
+      <t>Included here is a simple format validator in Python for
+      self-published ipgeo feeds. This tool reads CSV data in the
+      self-published ipgeo feed format from the standard input and performs
+      basic validation. It is intended for use by feed publishers before
+      launching a feed. Note that this validator does not verify the
+      uniqueness of every IP prefix entry within the feed as a whole, but only
+      verifies the syntax of each single line from within the feed. A complete
+      validator MUST also ensure IP prefix uniqueness.</t>
+
+      <t>The main source file "ipgeo_feed_validator.py" follows. It requires
+      use of the open source ipaddr Python library for IP address and CIDR
+      parsing and validation <xref target="IPADDR_PY"/>.</t>
+
+      <t><figure>
+          <artwork><![CDATA[
 #!/usr/bin/python
 #
 # Copyright (c) 2012 IETF Trust and the persons identified as authors of
@@ -1130,16 +1049,14 @@ def main():
 if __name__ == '__main__':
   main()
             ]]></artwork>
-          </figure>
-        </t>
-        <t>
-A unit test file, "ipgeo_feed_validator_test.py" is provided as well.  It
-provides basic test coverage of the code above, though does not test correct
-handling of non-ASCII UTF-8 strings.
-        </t>
-        <t>
-          <figure>
-            <artwork><![CDATA[
+        </figure></t>
+
+      <t>A unit test file, "ipgeo_feed_validator_test.py" is provided as well.
+      It provides basic test coverage of the code above, though does not test
+      correct handling of non-ASCII UTF-8 strings.</t>
+
+      <t><figure>
+          <artwork><![CDATA[
 #!/usr/bin/python
 #
 # Copyright (c) 2012 IETF Trust and the persons identified as authors of
@@ -1246,8 +1163,7 @@ class IPGeoFeedValidatorTest(object):
 if __name__ == '__main__':
   IPGeoFeedValidatorTest().Run()
             ]]></artwork>
-          </figure>
-        </t>
-      </section>
+        </figure></t>
+    </section>
   </back>
 </rfc>


### PR DESCRIPTION
Changed the XML to make it valid ('TypeError: A DOCTYPE is not allowed in content.') and use new format.

Some additional background.

Added the IETF Netowork Feed as an example - it is probavbly the most familiar to most participants.

    Note that this is still a work in progress, need to update text, etc.